### PR TITLE
reconfigured travis to point to the scout urls instead of scoutproject

### DIFF
--- a/travis-ci/settings.py
+++ b/travis-ci/settings.py
@@ -60,7 +60,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.RemoteUserBackend',
 )
 
-ROOT_URLCONF = 'scoutproject.urls'
+ROOT_URLCONF = 'travis-ci.urls'
 
 TEMPLATES = [
     {

--- a/travis-ci/urls.py
+++ b/travis-ci/urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
 urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'project.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
+    url(r'^', include('scout.urls')),
 )
+


### PR DESCRIPTION
I had to do something like this on my branch in order for travis to run my tests that accessed the URL's, thought it might be good to add here
