### PR TITLE
Url test refactor

### DIFF
--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -12,31 +12,31 @@ redir = 301
 
 # Each of these will be turned into a test function
 _testCases = (
-    ('Home', '/', OK),  # SCOUT-52
-    ('Food', '/food/', OK),  # SCOUT-53
-    ('Filter', '/filter/', OK),  # SCOUT-54
-    ('Good Details Page', '/detail/1/', OK),
-    ('Nonexistant Details Page', '/detail/88888/', notfound),  # SCOUT-55
-    ('Malformed Details ID', '/detail/abcdefg', notfound),  # SCOUT-55
-    ('Malformed Details ID 2', '/detail/123456/', notfound),  # SCOUT-55
-    ('Nonexistant page', '/nonexistant/', notfound),  # SCOUT-56
-    ('Filter Open', '/food/?open_now=true', OK),  # SCOUT-76
-    ('Filter Coffee', '/food/?food0=s_food_espresso', OK),  # SCOUT-77
-    ('Filter Breakfast', '/food/?period0=breakfast', OK),  # SCOUT-79
-    ('Filter Latenight', '/food/?period0=late_night', OK),  # SCOUT-78
-    ('Invalid Filter Params', '/food/?open_now=invalid', OK),  # SCOUT-156
-    ('Invalid Filter Params 2', '/food/?blah', OK),  # SCOUT-156
-    ('Invalid Filter Params 3', '/food/?blah=blah', OK),  # SCOUT-156
-    ('Invalid Food URL', '/food/404', notfound),  # SCOUT-157
-    ('Bad Filter', '/filter/404', notfound),  # SCOUT-81
-    ('Home Missing Slash', '', OK),  # SCOUT-57
-    ('Food Missing Slash', '/food', redir),  # SCOUT-57
-    ('Filter Missing Slash', '/filter', redir),  # SCOUT-57
-    ('Details Missing Slash', '/detail/1234', redir),  # SCOUT-57
+    ('Home', '/', OK, 'SCOUT-52'),
+    ('Food', '/food/', OK, 'SCOUT-53'),
+    ('Filter', '/filter/', OK, 'SCOUT-54'),
+    ('Good Details Page', '/detail/1/', OK, 'SCOUT-58'),
+    ('Nonexistant Details Page', '/detail/88888/', notfound, 'SCOUT-55'),
+    ('Malformed Details ID', '/detail/abcdefg', notfound, 'SCOUT-55'),
+    ('Malformed Details ID 2', '/detail/123456/', notfound, 'SCOUT-55'),
+    ('Nonexistant page', '/nonexistant/', notfound, 'SCOUT-56'),
+    ('Filter Open', '/food/?open_now=true', OK, 'SCOUT-76'),
+    ('Filter Coffee', '/food/?food0=s_food_espresso', OK, 'SCOUT-77'),
+    ('Filter Breakfast', '/food/?period0=breakfast', OK, 'SCOUT-79'),
+    ('Filter Latenight', '/food/?period0=late_night', OK, 'SCOUT-78'),
+    ('Invalid Filter Params', '/food/?open_now=invalid', OK, 'SCOUT-156'),
+    ('Invalid Filter Params 2', '/food/?blah', OK, 'SCOUT-156'),
+    ('Invalid Filter Params 3', '/food/?blah=blah', OK, 'SCOUT-156'),
+    ('Invalid Food URL', '/food/404', notfound, 'SCOUT-157'),
+    ('Bad Filter', '/filter/404', notfound, 'SCOUT-81'),
+    ('Home Missing Slash', '', OK, 'SCOUT-57'),
+    ('Food Missing Slash', '/food', redir, 'SCOUT-57'),
+    ('Filter Missing Slash', '/filter', redir, 'SCOUT-57'),
+    ('Details Missing Slash', '/detail/1234', redir, 'SCOUT-57'),
 )
 
 
-def _makeTestFunc(name, url, status=OK):
+def _makeTestFunc(name, url, status=OK, issue=None):
     """
     Returns a function that tests the given URL using
     assertUrlStatus.
@@ -45,7 +45,10 @@ def _makeTestFunc(name, url, status=OK):
         self.assertUrlStatus(url, status)
 
     _testFunc.__name__ = 'test_page_' + name.replace(' ', '_').lower()
-    _testFunc.__doc__ = 'Assert "%s" results in a %s' % (url, status)
+    doc = 'Assert "%s" results in a %s' % (url, status)
+    if issue is not None:
+        doc += ' (%s)' % issue
+    _testFunc.__doc__ = doc
 
     return _testFunc
 

--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -72,3 +72,4 @@ class UrlStatusTest(TestCase):
         _testFunc = _makeTestFunc(*case)
         name = _testFunc.__name__
         vars()[name] = _testFunc
+    del case, name

--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -3,7 +3,6 @@
 Tests pages and their respective URL status codes
 """
 
-import sys
 from django.test import TestCase
 
 # Statuses

--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -44,8 +44,10 @@ class UrlStatusTest(TestCase):
         return res.status_code
 
     def assertUrlStatus(self, urlsuffix='', code=200):
-        """Checks to see if the status code of the given URL matches the
-        given status code"""
+        """
+        Checks to see if the status code of the given URL matches the
+        given status code.
+        """
         url_status = self._clientUrlStatus(urlsuffix)
         self.assertEqual(
             url_status, code,

--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -18,13 +18,14 @@ class UrlStatusTest(TestCase):
     (200, 301, or 404).
     """
 
+    # Each of these will be turned into a test function
     _testCases = (
         ('Home', '/', OK),  # SCOUT-52
         ('Food', '/food/', OK),  # SCOUT-53
         ('Filter', '/filter/', OK),  # SCOUT-54
         ('Good Details Page', '/detail/1/', OK),
         ('Nonexistant Details Page', '/detail/88888/', notfound),  # SCOUT-55
-        ('Malformed Details ID', '/detail/abcdefg', notfound),  # SCOUT-55?
+        ('Malformed Details ID', '/detail/abcdefg', notfound),
         ('Malformed Details ID 2', '/detail/123456/', notfound),
         ('Nonexistant page', '/nonexistant/', notfound),  # SCOUT-56
         ('Filter Open', '/food/?open_now=true', OK),  # SCOUT-76
@@ -32,10 +33,10 @@ class UrlStatusTest(TestCase):
         ('Filter Breakfast', '/food/?period0=breakfast', OK),  # SCOUT-79
         ('Filter Latenight', '/food/?period0=late_night', OK),  # SCOUT-78
         ('Bad Filter', '/filter/404', notfound),  # SCOUT-81
-        ('Home Missing Slash', '', OK),  # SCOUT-57?
-        ('Food Missing Slash', '/food', redir),  # SCOUT-57?
-        ('Filter Missing Slash', '/filter', redir),  # SCOUT-57?
-        ('Details Missing Slash', '/detail/1234', redir),  # SCOUT-57?
+        ('Home Missing Slash', '', OK),
+        ('Food Missing Slash', '/food', redir),
+        ('Filter Missing Slash', '/filter', redir),
+        ('Details Missing Slash', '/detail/1234', redir),
     )
 
     def _clientUrlStatus(self, urlsuffix=''):
@@ -45,8 +46,8 @@ class UrlStatusTest(TestCase):
 
     def assertUrlStatus(self, urlsuffix='', code=200):
         """
-        Checks to see if the status code of the given URL matches the
-        given status code.
+        Asserts that the given url (path only) returns the given
+        status code.
         """
         url_status = self._clientUrlStatus(urlsuffix)
         self.assertEqual(
@@ -56,20 +57,21 @@ class UrlStatusTest(TestCase):
 
     def _makeTestFunc(name, url, status=OK):
         """
-        Returns a function that asserts that the given url results in the
-        given status code, after setting its name and docstring accordingly.
+        Returns a function that tests the given URL using
+        assertUrlStatus.
         """
         def _testFunc(self):
             self.assertUrlStatus(url, status)
 
         _testFunc.__name__ = 'test_page_' + name.replace(' ', '_').lower()
-        _testFunc.__doc__ = (
-            'Assert "%s" results in a %s' % (url, status))
+        _testFunc.__doc__ = 'Assert "%s" results in a %s' % (url, status)
 
         return _testFunc
 
+    # Generate a test function from each test case tuple
     for case in _testCases:
         _testFunc = _makeTestFunc(*case)
         name = _testFunc.__name__
         vars()[name] = _testFunc
-    del case, name
+    # Cleanup so temp vars don't clutter automatically-generated docs
+    del case, name, _makeTestFunc

--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -11,33 +11,47 @@ OK = 200
 notfound = 404
 redir = 301
 
+# Each of these will be turned into a test function
+_testCases = (
+    ('Home', '/', OK),  # SCOUT-52
+    ('Food', '/food/', OK),  # SCOUT-53
+    ('Filter', '/filter/', OK),  # SCOUT-54
+    ('Good Details Page', '/detail/1/', OK),
+    ('Nonexistant Details Page', '/detail/88888/', notfound),  # SCOUT-55
+    ('Malformed Details ID', '/detail/abcdefg', notfound),
+    ('Malformed Details ID 2', '/detail/123456/', notfound),
+    ('Nonexistant page', '/nonexistant/', notfound),  # SCOUT-56
+    ('Filter Open', '/food/?open_now=true', OK),  # SCOUT-76
+    ('Filter Coffee', '/food/?food0=s_food_espresso', OK),  # SCOUT-77
+    ('Filter Breakfast', '/food/?period0=breakfast', OK),  # SCOUT-79
+    ('Filter Latenight', '/food/?period0=late_night', OK),  # SCOUT-78
+    ('Bad Filter', '/filter/404', notfound),  # SCOUT-81
+    ('Home Missing Slash', '', OK),
+    ('Food Missing Slash', '/food', redir),
+    ('Filter Missing Slash', '/filter', redir),
+    ('Details Missing Slash', '/detail/1234', redir),
+)
+
+
+def _makeTestFunc(name, url, status=OK):
+    """
+    Returns a function that tests the given URL using
+    assertUrlStatus.
+    """
+    def _testFunc(self):
+        self.assertUrlStatus(url, status)
+
+    _testFunc.__name__ = 'test_page_' + name.replace(' ', '_').lower()
+    _testFunc.__doc__ = 'Assert "%s" results in a %s' % (url, status)
+
+    return _testFunc
+
 
 class UrlStatusTest(TestCase):
     """
     Ensure each listed URL/path results in the expected status code
     (200, 301, or 404).
     """
-
-    # Each of these will be turned into a test function
-    _testCases = (
-        ('Home', '/', OK),  # SCOUT-52
-        ('Food', '/food/', OK),  # SCOUT-53
-        ('Filter', '/filter/', OK),  # SCOUT-54
-        ('Good Details Page', '/detail/1/', OK),
-        ('Nonexistant Details Page', '/detail/88888/', notfound),  # SCOUT-55
-        ('Malformed Details ID', '/detail/abcdefg', notfound),
-        ('Malformed Details ID 2', '/detail/123456/', notfound),
-        ('Nonexistant page', '/nonexistant/', notfound),  # SCOUT-56
-        ('Filter Open', '/food/?open_now=true', OK),  # SCOUT-76
-        ('Filter Coffee', '/food/?food0=s_food_espresso', OK),  # SCOUT-77
-        ('Filter Breakfast', '/food/?period0=breakfast', OK),  # SCOUT-79
-        ('Filter Latenight', '/food/?period0=late_night', OK),  # SCOUT-78
-        ('Bad Filter', '/filter/404', notfound),  # SCOUT-81
-        ('Home Missing Slash', '', OK),
-        ('Food Missing Slash', '/food', redir),
-        ('Filter Missing Slash', '/filter', redir),
-        ('Details Missing Slash', '/detail/1234', redir),
-    )
 
     def _clientUrlStatus(self, urlsuffix=''):
         """Returns the status code of the given URL"""
@@ -55,23 +69,10 @@ class UrlStatusTest(TestCase):
             'URL "%s" returned %s, expected %s' % (urlsuffix, url_status, code)
         )
 
-    def _makeTestFunc(name, url, status=OK):
-        """
-        Returns a function that tests the given URL using
-        assertUrlStatus.
-        """
-        def _testFunc(self):
-            self.assertUrlStatus(url, status)
-
-        _testFunc.__name__ = 'test_page_' + name.replace(' ', '_').lower()
-        _testFunc.__doc__ = 'Assert "%s" results in a %s' % (url, status)
-
-        return _testFunc
-
     # Generate a test function from each test case tuple
     for case in _testCases:
         _testFunc = _makeTestFunc(*case)
         name = _testFunc.__name__
         vars()[name] = _testFunc
     # Cleanup so temp vars don't clutter automatically-generated docs
-    del case, name, _makeTestFunc
+    del case, name, _testFunc

--- a/scout/test/pageflow/page_load_status.py
+++ b/scout/test/pageflow/page_load_status.py
@@ -17,18 +17,22 @@ _testCases = (
     ('Filter', '/filter/', OK),  # SCOUT-54
     ('Good Details Page', '/detail/1/', OK),
     ('Nonexistant Details Page', '/detail/88888/', notfound),  # SCOUT-55
-    ('Malformed Details ID', '/detail/abcdefg', notfound),
-    ('Malformed Details ID 2', '/detail/123456/', notfound),
+    ('Malformed Details ID', '/detail/abcdefg', notfound),  # SCOUT-55
+    ('Malformed Details ID 2', '/detail/123456/', notfound),  # SCOUT-55
     ('Nonexistant page', '/nonexistant/', notfound),  # SCOUT-56
     ('Filter Open', '/food/?open_now=true', OK),  # SCOUT-76
     ('Filter Coffee', '/food/?food0=s_food_espresso', OK),  # SCOUT-77
     ('Filter Breakfast', '/food/?period0=breakfast', OK),  # SCOUT-79
     ('Filter Latenight', '/food/?period0=late_night', OK),  # SCOUT-78
+    ('Invalid Filter Params', '/food/?open_now=invalid', OK),  # SCOUT-156
+    ('Invalid Filter Params 2', '/food/?blah', OK),  # SCOUT-156
+    ('Invalid Filter Params 3', '/food/?blah=blah', OK),  # SCOUT-156
+    ('Invalid Food URL', '/food/404', notfound),  # SCOUT-157
     ('Bad Filter', '/filter/404', notfound),  # SCOUT-81
-    ('Home Missing Slash', '', OK),
-    ('Food Missing Slash', '/food', redir),
-    ('Filter Missing Slash', '/filter', redir),
-    ('Details Missing Slash', '/detail/1234', redir),
+    ('Home Missing Slash', '', OK),  # SCOUT-57
+    ('Food Missing Slash', '/food', redir),  # SCOUT-57
+    ('Filter Missing Slash', '/filter', redir),  # SCOUT-57
+    ('Details Missing Slash', '/detail/1234', redir),  # SCOUT-57
 )
 
 


### PR DESCRIPTION
Cleanup of old page_load_status.py
Test cases can now be specified on a single line, making the test structure more scalable. The actual test functions are generated at runtime, but in a way such that documentation can still be automatically generated (e.g. pydoc).
In addition, it is strictly one URL per test function, so failures will not block any other assertions, which was an outstanding issue with the old one.
Implements Craig's suggestion to rename clientUrlStatus to _clientUrlStatus.
Makes docstrings for test functions more consistent.
Adds a couple new test URLs.
