### PR TITLE
Added error-handling tests for dao

### DIFF
--- a/scout/tests.py
+++ b/scout/tests.py
@@ -1,5 +1,5 @@
 from django.conf import settings
 from django.utils import unittest
-from scout.test.dao.space_dao import SpaceDAOTest
+from scout.test.dao.space_dao import SpaceDAOTest, DAOErrorsTest
 from scout.test.pageflow.page_load_status import UrlStatusTest
 from scout.test.pageflow.navigation import MainNavigationTest


### PR DESCRIPTION
Uses a fake spot_client that always raises DataFailureExceptions to test error-handling behavior in the space dao. 
