### PR TITLE
Remove the animated content preloading after appending happens.

### DIFF
--- a/scout/static/hybridize/js/list.js
+++ b/scout/static/hybridize/js/list.js
@@ -42,7 +42,7 @@ var List = {
                 //then the Ajax request was successful.
                 var isource = $("#study-list-module-component").html();
                 var itemplate = Handlebars.compile(isource);
-                $("#scout_study_list").html("");
+                //$("#scout_study_list").html("");
                 $.each(data, function(index, object) {
                     List.load_spot_details(template, itemplate, object, campus);
                 });
@@ -78,10 +78,14 @@ var List = {
             promises.push(request);
         });
         $.when.apply(null, promises).done(function(){
+
             $("#scout_study_list").append(outer_template({
                 object: object,
                 inner_html: spot_html
             }));
+
+            //remove the content loading static after appending list
+            $("#fancy_content_loading").remove();
         });
     },
 

--- a/scout/templates/hybridize/study/list-performance.html
+++ b/scout/templates/hybridize/study/list-performance.html
@@ -31,7 +31,7 @@
             {% if count > 0 %}
             <!-- Data goes here -->
             <!-- fancy content placeholder -->
-            <li style="padding:0;" class="scout-list-building">
+            <li id="fancy_content_loading" style="padding:0;" class="scout-list-building">
 
                 <div class="list-group-title"><span class="content-loading" style="width:300px;">&nbsp;</span></div>
 


### PR DESCRIPTION
I think this looks better to the user. Append to the fancy loading list first - then remove the fancy loader leaving the fetched list.