### PR TITLE
Remove list loading css animation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+dist: precise
 python:
   - "2.7.6"
 install: 

--- a/scout/static/hybridize/css/android.scss
+++ b/scout/static/hybridize/css/android.scss
@@ -25,6 +25,9 @@ body { position: static !important; overflow: initial !important; height: auto !
 
 .list-block { margin: 0;
 
+    // removes transition animation for lists
+    .item-link { transition-duration: 0ms !important; }
+    
 	ul:before { height: 0; }
 
 	ul {

--- a/scout/static/hybridize/css/ios.scss
+++ b/scout/static/hybridize/css/ios.scss
@@ -1,5 +1,4 @@
 /*** framework 7 overrides ***/
-
 body { position: static !important; overflow: initial !important; height: auto !important; box-sizing: border-box; }
 
 .views { overflow: hidden !important; overflow-x: hidden !important; overflow-y: auto !important; }
@@ -11,6 +10,9 @@ body { position: static !important; overflow: initial !important; height: auto !
 }
 
 .list-block { margin: 0;
+
+    // removes transition animation for lists
+    .item-link { transition-duration: 0ms !important; }
 
 	ul:before { height: 0; }
 


### PR DESCRIPTION
Sets the transition duration to 0.. so that the list loads without animated movement (page shifting) when some pages are loaded in the hybrid webview.