### PR TITLE
Bug/scout 518

### DIFF
--- a/scout/templates/hybridize/food/detail.html
+++ b/scout/templates/hybridize/food/detail.html
@@ -31,7 +31,7 @@
 
     {% if spot.description %}
     <div class="list-block-label" style="margin-bottom:1em;">
-        {{ spot.description }}
+        {{ spot.description|urlize }}
     </div>
     {% endif %}
 

--- a/scout/templates/hybridize/study/detail.html
+++ b/scout/templates/hybridize/study/detail.html
@@ -86,7 +86,7 @@
     {% if spot.access_notes %}
     <div class="list-block-label" style="margin-bottom:1em;">
         <i class="fa fa-sign-in" aria-hidden="true" style="float:left; margin-top:3px;"></i>
-        <span style=" display:block; float:left; width: 92%;">{{spot.access_notes}}</span>
+        <span style=" display:block; float:left; width: 92%;">{{spot.access_notes|urlize}}</span>
         <div style="clear:both;"></div>
     </div>
     {% endif %}

--- a/scout/templates/scout/food/detail.html
+++ b/scout/templates/scout/food/detail.html
@@ -124,7 +124,7 @@
 
             {% if spot.description %}
             <h3>Description</h3>
-            <div class="scout-spot-description">{{spot.description}}</div>
+            <div class="scout-spot-description">{{spot.description|urlize}}</div>
             {% endif %}
         </div>
 


### PR DESCRIPTION
https://jira.cac.washington.edu/browse/SCOUT-518

Simply added a urlize filter for both regular and hybrid food spot `Descriptions`.

Also noticed that for study spots' `Access Notes`, the behavior in the regular and hybrid sites are different.

The regular site urlizes the `Access Notes`, the hybrid doesn't (so I changed the hybrid version to urlize as well):
https://scout.uw.edu/seattle/study/1270/
https://scout.uw.edu/h/seattle/study/1270/
