### PR TITLE
Bug/scout 705

### DIFF
--- a/scout/static/hybridize/css/android.scss
+++ b/scout/static/hybridize/css/android.scss
@@ -95,7 +95,7 @@ body { font-family: 'Roboto', sans-serif; }
 .item-input { text-align: right;
     input, select { text-align: right }
 
-    select { display: inline-block; margin-right: 0; width: auto; height: auto }
+    select { display: inline-block; margin-right: 0; width: auto;}
 }
 // helpers
 

--- a/scout/static/hybridize/css/android.scss
+++ b/scout/static/hybridize/css/android.scss
@@ -92,7 +92,11 @@ body { font-family: 'Roboto', sans-serif; }
     span, select { display:inline-block; }
 }
 
+.item-input { text-align: right;
+    input, select { text-align: right }
 
+    select { display: inline-block; margin-right: 0; width: auto; height: auto }
+}
 // helpers
 
 .visually-hidden {

--- a/scout/static/hybridize/css/ios.scss
+++ b/scout/static/hybridize/css/ios.scss
@@ -73,7 +73,7 @@ label.label-radio input[type=checkbox]:checked~.item-inner, label.label-radio in
 .item-input { text-align: right;
 	input, select { text-align: right; }
 
-	/*select { width: auto; margin-right: 0; display: inline-block; }*/
+	select { width: auto; margin-right: 0; display: inline-block; }
 }
 
 /** cards not really in ios.. flat and full width **/

--- a/scout/static/hybridize/css/ios.scss
+++ b/scout/static/hybridize/css/ios.scss
@@ -72,8 +72,8 @@ label.label-radio input[type=checkbox]:checked~.item-inner, label.label-radio in
 
 .item-input { text-align: right;
 	input, select { text-align: right; }
-
-	select { width: auto; margin-right: 0; display: inline-block; }
+	
+    select { width: auto; margin-right: 0; display: inline-block; }
 }
 
 /** cards not really in ios.. flat and full width **/

--- a/scout/templates/hybridize/study/filter.html
+++ b/scout/templates/hybridize/study/filter.html
@@ -274,7 +274,7 @@
             <li>
                 <div class="item-content">
                     <div class="item-inner">
-                        <div class="item-title label">Seats at least</div>
+                        <div class="item-title label" style="width:75%">Seats at least</div>
                         <div class="item-input">
                             <select>
                                 <option value="1">1</option>

--- a/scout/templates/hybridize/study/filter.html
+++ b/scout/templates/hybridize/study/filter.html
@@ -255,7 +255,7 @@
             <li>
             <div class="item-content">
             <div class="item-inner">
-            <div class="item-title label" style="width:75%;">Show reservable spaces only</div>
+            <div class="item-title label" style="width:75%;">Only reservable</div>
             <div class="item-input">
             <label class="label-switch">
             <input type="checkbox" value="reservable">

--- a/scout/templates/scout/study/filter.html
+++ b/scout/templates/scout/study/filter.html
@@ -80,8 +80,9 @@
                 </fieldset>
 
                 <fieldset class="">
-                    <legend>Seats at least</legend>
+                    <legend>Capacity</legend>
                     <div id="capacity_select">
+                        <label>Seats at least: 
                         <select>
                             <option value="1">1</option>
                             <option value="2">2</option>
@@ -97,6 +98,7 @@
                             <option value="20">20</option>
                             <option value="25">25+</option>
                        </select>
+                       </label>
                     </div>
                 </fieldset>
 

--- a/scout/templates/scout/study/filter.html
+++ b/scout/templates/scout/study/filter.html
@@ -75,7 +75,7 @@
                 <fieldset class="">
                     <legend>Reservability</legend>
                     <div id="reserve_select">
-                        <label><input type="checkbox" value="reservable" />Show reservable spaces only</label>
+                        <label><input type="checkbox" value="reservable" />Only reservable</label>
                     </div>
                 </fieldset>
 


### PR DESCRIPTION
fixes:SCOUT-706 as well. 

Changed "Show reserveable spaces only" to "Only reservable" in the study filter page because the old label was too long and was getting cut off on mobile devices. 

Moved the capacity label to above the selector on web for consistency.

Moved the capacity selector to hr right to make room for its label.

## Before:
![image](https://user-images.githubusercontent.com/19562094/36172564-253f0ee6-10bb-11e8-80fb-db59d0de9485.png)
(Web)

![image](https://user-images.githubusercontent.com/19562094/36172622-50540fc8-10bb-11e8-8fd5-30bf1345b985.png)
(iPhone 5 hybrid)

## After:
![image](https://user-images.githubusercontent.com/19562094/36172728-a8e5811c-10bb-11e8-99fe-773f613045ac.png)
(Web)

![image](https://user-images.githubusercontent.com/19562094/36172750-bc2de8a4-10bb-11e8-9bf4-ce505ef166bf.png)
(iPhone 5 hybrid)