### PR TITLE
Fixes lat lng bug on discover web and hybrid logic.

### DIFF
--- a/scout/templates/hybridize/discover.html
+++ b/scout/templates/hybridize/discover.html
@@ -124,11 +124,11 @@
 </div>
 
 {% if campus == 'seattle' %}
-<div id="discover_cards" data-campus="{{campus}}" data-campus-latitude="{{ campus_locations.seattle.latitude }}" data-campus-longitude="{{ campus_locations.seattle.longitude }}">
+<div id="discover_cards" data-campus="{{campus}}" {% if request.GET.h_lat and request.GET.h_lng %}data-user-latitude="{{ request.GET.h_lat }}" data-user-longitude="{{ request.GET.h_lng }}"{% else %}data-campus-latitude="{{ campus_locations.seattle.latitude }}" data-campus-longitude="{{ campus_locations.seattle.longitude }}"{% endif %} {% if request.is_and %}data-device="android"{% else %}data-device="ios"{% endif %}>
 {% elif campus == 'bothell' %}
-<div id="discover_cards" data-campus="{{campus}}" data-campus-latitude="{{ campus_locations.bothell.latitude }}" data-campus-longitude="{{ campus_locations.bothell.longitude }}">
+<div id="discover_cards" data-campus="{{campus}}" {% if request.GET.h_lat and request.GET.h_lng %}data-user-latitude="{{ request.GET.h_lat }}" data-user-longitude="{{ request.GET.h_lng }}"{% else %}data-campus-latitude="{{ campus_locations.bothell.latitude }}" data-campus-longitude="{{ campus_locations.bothell.longitude }}"{% endif %} {% if request.is_and %}data-device="android"{% else %}data-device="ios"{% endif %}>
 {% elif campus == 'tacoma' %}
-<div id="discover_cards" data-campus="{{campus}}" data-campus-latitude="{{ campus_locations.tacoma.latitude }}" data-campus-longitude="{{ campus_locations.tacoma.longitude }}">
+<div id="discover_cards" data-campus="{{campus}}" {% if request.GET.h_lat and request.GET.h_lng %}data-user-latitude="{{ request.GET.h_lat }}" data-user-longitude="{{ request.GET.h_lng }}"{% else %}data-campus-latitude="{{ campus_locations.tacoma.latitude }}" data-campus-longitude="{{ campus_locations.tacoma.longitude }}"{% endif %} {% if request.is_and %}data-device="android"{% else %}data-device="ios"{% endif %}>
 {% endif %}
 
     <!-- containers for displaying cards -->

--- a/scout/views.py
+++ b/scout/views.py
@@ -59,7 +59,14 @@ class DiscoverCardView(TemplateView):
     def get_context_data(self, **kwargs):
         self.template_name = kwargs['template_name']
 
-        # Will figure this out later
+        # if h_lat and h_lng is provided, use it
+        # otherwise, user latitude and longitude
+
+        # handle hybridize user lat/lng requests
+        hlat = self.request.GET.get('h_lat', None)
+        hlon = self.request.GET.get('h_lng', None)
+
+        # handle standard lat/lng requests for web
         lat = self.request.GET.get('latitude', None)
         lon = self.request.GET.get('longitude', None)
 
@@ -72,8 +79,10 @@ class DiscoverCardView(TemplateView):
                 "filter": [
                     ('limit', 5),
                     ('open_now', True),
-                    ('center_latitude', lat if lat else DEFAULT_LAT),
-                    ('center_longitude', lon if lon else DEFAULT_LON),
+                    ('center_latitude', hlat if hlat else lat if lat else
+                        DEFAULT_LAT),
+                    ('center_longitude', hlon if hlon else lon if lon else
+                        DEFAULT_LON),
                     ('distance', 100000),
                     ('extended_info:app_type', 'food')
                     ]
@@ -84,8 +93,10 @@ class DiscoverCardView(TemplateView):
                 "filter_url": "period0=morning",
                 "filter": [
                     ('limit', 5),
-                    ('center_latitude', lat if lat else DEFAULT_LAT),
-                    ('center_longitude', lon if lon else DEFAULT_LON),
+                    ('center_latitude', hlat if hlat else lat if lat else
+                        DEFAULT_LAT),
+                    ('center_longitude', hlon if hlon else lon if lon else
+                        DEFAULT_LON),
                     ('distance', 100000),
                     ('extended_info:app_type', 'food')
                     ] + get_period_filter('morning')
@@ -97,8 +108,10 @@ class DiscoverCardView(TemplateView):
                 "filter_url": "period0=late_night",
                 "filter": [
                     ('limit', 5),
-                    ('center_latitude', lat if lat else DEFAULT_LAT),
-                    ('center_longitude', lon if lon else DEFAULT_LON),
+                    ('center_latitude', hlat if hlat else lat if lat else
+                        DEFAULT_LAT),
+                    ('center_longitude', hlon if hlon else lon if lon else
+                        DEFAULT_LON),
                     ('distance', 100000),
                     ('extended_info:app_type', 'food')
                     ] + get_period_filter('late_night')
@@ -109,8 +122,10 @@ class DiscoverCardView(TemplateView):
                 "filter_url": "type0=outdoor",
                 "filter": [
                     ('limit', 5),
-                    ('center_latitude', lat if lat else DEFAULT_LAT),
-                    ('center_longitude', lon if lon else DEFAULT_LON),
+                    ('center_latitude', hlat if hlat else lat if lat else
+                        DEFAULT_LAT),
+                    ('center_longitude', hlon if hlon else lon if lon else
+                        DEFAULT_LON),
                     ('distance', 100000),
                     ('type', 'outdoor')
                     ]
@@ -121,8 +136,10 @@ class DiscoverCardView(TemplateView):
                 "filter_url": "type0=computer_lab",
                 "filter": [
                     ('limit', 5),
-                    ('center_latitude', lat if lat else DEFAULT_LAT),
-                    ('center_longitude', lon if lon else DEFAULT_LON),
+                    ('center_latitude', hlat if hlat else lat if lat else
+                        DEFAULT_LAT),
+                    ('center_longitude', hlon if hlon else lon if lon else
+                        DEFAULT_LON),
                     ('distance', 100000),
                     ('type', 'computer_lab')
                 ]


### PR DESCRIPTION
This fixes the discover card bug that we found.

The view.py for Scout will handle BOTH "h_lat/h_lng" and "latitude/longitude" requests now.